### PR TITLE
[FEAT] KAKAO 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-common:2.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/groom/swipo/domain/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/groom/swipo/domain/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,6 @@
+package com.groom.swipo.domain.auth.dto.request;
+
+public record KakaoLoginRequest(
+	String kakaoCode
+) {
+}

--- a/src/main/java/com/groom/swipo/domain/auth/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/groom/swipo/domain/auth/dto/response/KakaoLoginResponse.java
@@ -1,0 +1,27 @@
+package com.groom.swipo.domain.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record KakaoLoginResponse(
+	Long userId,
+	String accessToken,
+	String refreshToken,
+	String providerId,
+	String profileImage
+) {
+	public static KakaoLoginResponse of(Long userId, String accessToken, String refreshToken) {
+		return KakaoLoginResponse.builder()
+			.userId(userId)
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	public static KakaoLoginResponse of(String providerId, String profileImage) {
+		return KakaoLoginResponse.builder()
+			.providerId(providerId)
+			.profileImage(profileImage)
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/auth/exception/KakaoAuthException.java
+++ b/src/main/java/com/groom/swipo/domain/auth/exception/KakaoAuthException.java
@@ -1,0 +1,13 @@
+package com.groom.swipo.domain.auth.exception;
+
+import com.groom.swipo.global.error.exception.AuthGroupException;
+
+public class KakaoAuthException extends AuthGroupException {
+	public KakaoAuthException(String message) {
+		super(message);
+	}
+
+	public KakaoAuthException() {
+		this("카카오 서버와의 통신 과정에서 문제가 발생했습니다.");
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/groom/swipo/domain/auth/service/KakaoLoginService.java
@@ -1,0 +1,105 @@
+package com.groom.swipo.domain.auth.service;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groom.swipo.domain.auth.dto.response.KakaoLoginResponse;
+import com.groom.swipo.domain.auth.exception.KakaoAuthException;
+import com.groom.swipo.domain.user.entity.User;
+import com.groom.swipo.domain.user.entity.enums.Provider;
+import com.groom.swipo.domain.user.repository.UserRepository;
+import com.groom.swipo.global.jwt.TokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+	private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+	private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+	private final UserRepository userRepository;
+	private final TokenProvider tokenProvider;
+	private final TokenRenewService tokenRenewService;
+	private final RestClient restClient;
+	private final ObjectMapper objectMapper;
+
+	@Value("${oauth.kakao.client-id}")
+	private String clientId;
+
+	@Value("${oauth.kakao.client-secret}")
+	private String clientSecret;
+
+	@Value("${oauth.kakao.redirect-uri}")
+	private String redirectUri;
+
+	@Transactional
+	public KakaoLoginResponse kakaoLogin(String code) {
+		try {
+			String kakaoAccessToken = getKakaoAccessToken(code);
+			String[] userInfo = getKakaoUserInfo(kakaoAccessToken);
+
+			return userRepository.findByProviderAndProviderId(Provider.KAKAO, userInfo[0])
+				.map(this::handleExistingUserLogin)
+				.orElseGet(() -> KakaoLoginResponse.of(userInfo[0], userInfo[1]));
+		} catch (JsonProcessingException e) {
+			throw new KakaoAuthException();
+		}
+	}
+
+	private KakaoLoginResponse handleExistingUserLogin(User user) {
+		String accessToken = tokenProvider.createAccessToken(user);
+		String refreshToken = tokenProvider.createRefreshToken(user);
+		tokenRenewService.saveRefreshToken(refreshToken, user.getId());
+		return KakaoLoginResponse.of(user.getId(), accessToken, refreshToken);
+	}
+
+	private String getKakaoAccessToken(String code) throws JsonProcessingException {
+		String url = UriComponentsBuilder.fromHttpUrl(TOKEN_URL)
+			.queryParam("grant_type", "authorization_code")
+			.queryParam("client_id", clientId)
+			.queryParam("redirect_uri", redirectUri)
+			.queryParam("code", code)
+			.queryParam("client_secret", clientSecret)
+			.toUriString();
+
+		String response = restClient.post()
+			.uri(url)
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.body(String.class);
+
+		JsonNode jsonNode = objectMapper.readTree(response);
+		return jsonNode.get("access_token").asText();
+	}
+
+	private String[] getKakaoUserInfo(String kakaoAccessToken) throws JsonProcessingException {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + kakaoAccessToken);
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		String response = restClient.get()
+			.uri(URI.create(USER_INFO_URL))
+			.headers(httpHeaders -> httpHeaders.addAll(headers))
+			.retrieve()
+			.body(String.class);
+
+		JsonNode jsonNode = objectMapper.readTree(response);
+		String providerId = jsonNode.get("id").asText();
+		String profileImageUrl = jsonNode.path("kakao_account").path("profile").path("profile_image_url").asText();
+
+		return new String[] {providerId, profileImageUrl};
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/user/controller/UserController.java
+++ b/src/main/java/com/groom/swipo/domain/user/controller/UserController.java
@@ -11,16 +11,31 @@ import com.groom.swipo.domain.auth.dto.response.TokenRefreshResponse;
 import com.groom.swipo.domain.auth.service.TokenRenewService;
 import com.groom.swipo.global.template.ResTemplate;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/v1/user")
 @RequiredArgsConstructor
+@RequestMapping("/v1/user")
+@Tag(name = "사용자 정보", description = "사용자 정보를 담당하는 API 그룹")
 public class UserController {
 
 	private final TokenRenewService tokenRenewService;
 
 	@PostMapping("/tokenRefresh")
+	@Operation(
+		summary = "accessToken 재발급",
+		description = "refreshToken을 사용하여 새로운 accessToken을 발급합니다.",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "재발급 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "만료된 토큰"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
 	public ResTemplate<TokenRefreshResponse> refreshAccessToken(@RequestBody TokenRefreshRequest request) {
 		TokenRefreshResponse data = tokenRenewService.renewAccessToken(request);
 		return new ResTemplate<>(HttpStatus.OK, "재발급 성공", data);

--- a/src/main/java/com/groom/swipo/domain/user/controller/UserController.java
+++ b/src/main/java/com/groom/swipo/domain/user/controller/UserController.java
@@ -6,8 +6,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.groom.swipo.domain.auth.dto.request.KakaoLoginRequest;
 import com.groom.swipo.domain.auth.dto.request.TokenRefreshRequest;
+import com.groom.swipo.domain.auth.dto.response.KakaoLoginResponse;
 import com.groom.swipo.domain.auth.dto.response.TokenRefreshResponse;
+import com.groom.swipo.domain.auth.service.KakaoLoginService;
 import com.groom.swipo.domain.auth.service.TokenRenewService;
 import com.groom.swipo.global.template.ResTemplate;
 
@@ -19,15 +22,37 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/user")
-@Tag(name = "사용자 정보", description = "사용자 정보를 담당하는 API 그룹")
+@Tag(name = "사용자", description = "사용자를 담당하는 API 그룹")
 public class UserController {
 
+	private final KakaoLoginService kakaoLoginService;
 	private final TokenRenewService tokenRenewService;
+
+	@PostMapping("/kakao")
+	@Operation(
+		summary = "카카오 로그인",
+		description = "카카오 인가 코드를 사용하여 로그인 또는 회원가입 필요 여부를 판별합니다. DB에 사용자 정보가 있으면 로그인 성공, 없으면 회원가입 필요 상태를 반환합니다.",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "로그인 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "유효하지 않은 인가 코드"),
+			@ApiResponse(responseCode = "418", description = "회원가입 필요"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
+	public ResTemplate<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+		KakaoLoginResponse data = kakaoLoginService.kakaoLogin(request.kakaoCode());
+		if (data.userId() == null) {
+			return new ResTemplate<>(HttpStatus.I_AM_A_TEAPOT, "회원가입 필요", data);
+		}
+		return new ResTemplate<>(HttpStatus.OK, "로그인 성공", data);
+	}
 
 	@PostMapping("/tokenRefresh")
 	@Operation(
-		summary = "accessToken 재발급",
-		description = "refreshToken을 사용하여 새로운 accessToken을 발급합니다.",
+		summary = "액세스 토큰 재발급",
+		description = "리프레쉬 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.",
 		security = {},
 		responses = {
 			@ApiResponse(responseCode = "200", description = "재발급 성공"),

--- a/src/main/java/com/groom/swipo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/groom/swipo/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import com.groom.swipo.domain.user.entity.enums.Provider;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/groom/swipo/global/ProfileController.java
+++ b/src/main/java/com/groom/swipo/global/ProfileController.java
@@ -7,6 +7,9 @@ import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
 @RestController
 public class ProfileController {
 

--- a/src/main/java/com/groom/swipo/global/config/AppConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.groom.swipo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class AppConfig {
+
+	@Bean
+	public RestClient restClient() {
+		return RestClient.create();
+	}
+}

--- a/src/main/java/com/groom/swipo/global/config/SecurityConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/SecurityConfig.java
@@ -21,7 +21,10 @@ public class SecurityConfig {
 
 	private final TokenProvider tokenprovider;
 	private final String[] PERMIT_ALL_URLS = {
-		"/v1/**", "/profile"
+		"swagger-ui/**",
+		"v3/api-docs/**",
+		"/v1/**",
+		"/profile"
 	};
 
 	@Bean

--- a/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.groom.swipo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	private Info apiInfo() {
+		return new Info()
+			.version("v1.0.0")
+			.title("Swipo API")
+			.description("Swipo API 명세서");
+	}
+
+	@Bean
+	public OpenAPI openAPI() {
+		String authHeader = "Authorization";
+
+		return new OpenAPI()
+			.info(apiInfo())
+			.addSecurityItem(new SecurityRequirement().addList(authHeader))
+			.components(new Components()
+				.addSecuritySchemes(authHeader, new SecurityScheme()
+					.name(authHeader)
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("Bearer")
+					.bearerFormat("JWT")));
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,9 @@ jwt:
   expire-time:
     access-token: ${jwt.expire-time.access-token}
     refresh-token: ${jwt.expire-time.refresh-token}
+
+oauth:
+  kakao:
+    client-id: ${oauth.kakao.client-id}
+    client-secret: ${oauth.kakao.client-secret}
+    redirect-uri: ${oauth.kakao.redirect-uri}


### PR DESCRIPTION
## 📌 이슈 번호
> #10 

## 💬 리뷰 포인트
> KAKAO 로그인 구현 및 스웨거 적용

## 🚀 상세 설명
> 소셜 로그인 로직에서 `RestTemplate` 대신, 교내 스터디에서 접한 `RestClient`를 사용해봤습니다. 확실히 코드 가독성을 높이고, 간결하게 처리할 수 있어서 깔끔하다고 느꼈습니다!

[RestClient 공식문서](https://spring.io/blog/2023/07/13/new-in-spring-6-1-restclient)

## 📸 스크린샷

![카카오 로그인 성공](https://github.com/user-attachments/assets/770f9093-ddfe-4bbf-b661-84a939e4c7f3)

<img width="508" alt="토큰 재발급_Swagger" src="https://github.com/user-attachments/assets/2c29858c-62cc-4eb6-ad58-a8fab2ed88a2">

## 📢 노트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced Kakao login functionality, allowing users to authenticate using their Kakao accounts.
  - Added Swagger configuration for improved API documentation visibility.
  
- **Bug Fixes**
  - Enhanced error handling during Kakao authentication processes.

- **Documentation**
  - Updated API documentation with detailed descriptions for new endpoints and methods related to Kakao login.
  
- **Chores**
  - Added new OAuth settings for Kakao in the configuration file.
  - Updated security configuration to permit access to Swagger documentation endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->