### PR TITLE
[FEAT] 가게 검색 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,6 @@ dependencies {
 	// iamport
 	implementation 'com.github.iamport:iamport-rest-client-java:0.1.6'
 
-	// spring security
-	implementation("org.springframework.boot:spring-boot-starter-security")
-
 	// 휴대폰 인증 API (nurigo)
 	implementation 'net.nurigo:sdk:4.3.0'
 }

--- a/src/main/java/com/groom/swipo/domain/auth/util/JwtValidator.java
+++ b/src/main/java/com/groom/swipo/domain/auth/util/JwtValidator.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import lombok.RequiredArgsConstructor;
 
 // 해당 코드는 Jwt 전체에 대해 검증하는 것이 아닌 애플 로그인떄 받아오는 itentity token 검증용
 @Component

--- a/src/main/java/com/groom/swipo/domain/payment/dto/request/PaymentCompleteRequest.java
+++ b/src/main/java/com/groom/swipo/domain/payment/dto/request/PaymentCompleteRequest.java
@@ -1,9 +1,20 @@
 package com.groom.swipo.domain.payment.dto.request;
 
+import com.groom.swipo.domain.payment.entity.Pay;
+import com.groom.swipo.domain.payment.entity.Paylist;
+import com.groom.swipo.domain.store.entity.Store;
+
 public record PaymentCompleteRequest(
 	Long storeId,
 	String password,
 	Integer amount,
 	Integer usedPoints
 ) {
+	public Paylist toEntity(Pay pay, Store store) {
+		return Paylist.builder()
+			.value(amount - usedPoints)
+			.pay(pay)
+			.store(store)
+			.build();
+	}
 }

--- a/src/main/java/com/groom/swipo/domain/payment/entity/Paylist.java
+++ b/src/main/java/com/groom/swipo/domain/payment/entity/Paylist.java
@@ -1,13 +1,10 @@
 package com.groom.swipo.domain.payment.entity;
 
 import com.groom.swipo.domain.store.entity.Store;
-import com.groom.swipo.global.common.enums.Area;
 import com.groom.swipo.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -42,7 +39,9 @@ public class Paylist extends BaseEntity {
 	private Store store;
 
 	@Builder
-	private Paylist(long value) {
+	private Paylist(long value, Pay pay, Store store) {
 		this.value = value;
+		this.pay = pay;
+		this.store = store;
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/groom/swipo/domain/payment/service/PaymentService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.groom.swipo.domain.payment.dto.request.PaymentCompleteRequest;
 import com.groom.swipo.domain.payment.dto.response.PaymentCompleteResponse;
 import com.groom.swipo.domain.payment.dto.response.PaymentPageResponse;
+import com.groom.swipo.domain.payment.entity.Paylist;
 import com.groom.swipo.domain.payment.exception.PasswordMismatchException;
 import com.groom.swipo.domain.point.entity.Card;
 import com.groom.swipo.domain.point.exception.CardNotFoundException;
@@ -66,6 +67,9 @@ public class PaymentService {
 
 		user.getPay().updatePay(-netPayment);
 		card.updatePoint(earnedPoints - request.usedPoints());
+
+		Paylist paylist = request.toEntity(user.getPay(), store);
+		user.getPay().getPaylists().add(paylist);
 
 		return PaymentCompleteResponse.of(request.amount(), earnedPoints, user.getPay().getTotalPay());
 	}

--- a/src/main/java/com/groom/swipo/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/groom/swipo/domain/payment/service/PaymentService.java
@@ -2,6 +2,7 @@ package com.groom.swipo.domain.payment.service;
 
 import java.security.Principal;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,7 @@ public class PaymentService {
 
 	private final UserRepository userRepository;
 	private final StoreRepository storeRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public PaymentPageResponse getPaymentPage(Long storeId, Principal principal) {
 		Long userId = Long.parseLong(principal.getName());
@@ -54,7 +56,7 @@ public class PaymentService {
 			.findFirst()
 			.orElseThrow(CardNotFoundException::new);
 
-		if (!user.getPassword().equals(request.password())) {
+		if (!passwordEncoder.matches(request.password(), user.getPassword())) {
 			throw new PasswordMismatchException();
 		}
 

--- a/src/main/java/com/groom/swipo/domain/point/dto/PieceInfo.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/PieceInfo.java
@@ -10,7 +10,7 @@ public record PieceInfo(
 	String myPieceId,
 	String pieceName
 ) {
-	public static PieceInfo from(MyPiece myPiece,Piece piece) {
+	public static PieceInfo of(MyPiece myPiece,Piece piece) {
 		return PieceInfo.builder()
 			.myPieceId(String.valueOf(myPiece.getId()))
 			.pieceName(piece.getName())

--- a/src/main/java/com/groom/swipo/domain/point/entity/Cardlist.java
+++ b/src/main/java/com/groom/swipo/domain/point/entity/Cardlist.java
@@ -1,13 +1,10 @@
 package com.groom.swipo.domain.point.entity;
 
 import com.groom.swipo.domain.store.entity.Store;
-import com.groom.swipo.global.common.enums.Area;
 import com.groom.swipo.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/groom/swipo/domain/point/repository/MyPieceRepository.java
+++ b/src/main/java/com/groom/swipo/domain/point/repository/MyPieceRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.groom.swipo.domain.point.dto.PieceInfo;
 import com.groom.swipo.domain.point.entity.MyPiece;
 import com.groom.swipo.domain.user.entity.User;
 

--- a/src/main/java/com/groom/swipo/domain/point/service/PointService.java
+++ b/src/main/java/com/groom/swipo/domain/point/service/PointService.java
@@ -41,7 +41,7 @@ public class PointService {
 		}
 
 		List<PieceInfo> pieces = myPieces.stream()
-			.map(myPiece -> PieceInfo.from(myPiece, myPiece.getPiece()))
+			.map(myPiece -> PieceInfo.of(myPiece, myPiece.getPiece()))
 			.toList();
 
 		Integer piecesNum = pieces.size();

--- a/src/main/java/com/groom/swipo/domain/store/controller/StoreController.java
+++ b/src/main/java/com/groom/swipo/domain/store/controller/StoreController.java
@@ -14,6 +14,7 @@ import com.groom.swipo.domain.store.dto.request.ReviewsRegisterRequest;
 import com.groom.swipo.domain.store.dto.response.MapQueryResponse;
 import com.groom.swipo.domain.store.dto.response.MapStoreDetailResponse;
 import com.groom.swipo.domain.store.dto.response.MapTabViewResponse;
+import com.groom.swipo.domain.store.dto.response.StoreSearchResponse;
 import com.groom.swipo.domain.store.service.ReviewsService;
 import com.groom.swipo.domain.store.service.StoreService;
 import com.groom.swipo.domain.store.service.WishlistService;
@@ -124,5 +125,17 @@ public class StoreController {
 	public ResTemplate<MapTabViewResponse> getStoreTabs(Principal principal) {
 		MapTabViewResponse data = storeService.getStoreTabs(principal);
 		return new ResTemplate<>(HttpStatus.OK, "탭별 가게 조회 성공", data);
+	}
+
+	@GetMapping("/search")
+	public ResTemplate<StoreSearchResponse> searchStores(
+		@RequestParam(name = "keyword") String keyword,
+		@RequestParam(name = "category", defaultValue = "all") String category,
+		@RequestParam(name = "type") String type,
+		@RequestParam(name = "page", defaultValue = "0") int page,
+		Principal principal
+	) {
+		StoreSearchResponse data = storeService.searchStores(keyword, category, type, page, principal);
+		return new ResTemplate<>(HttpStatus.OK, "가게 검색 성공", data);
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/store/controller/StoreController.java
+++ b/src/main/java/com/groom/swipo/domain/store/controller/StoreController.java
@@ -128,6 +128,18 @@ public class StoreController {
 	}
 
 	@GetMapping("/search")
+	@Operation(
+		summary = "가게 검색",
+		description = "키워드, 카테고리, 타입별, 페이지로 필터링된 가게 리스트를 반환합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "가게 검색 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+			@ApiResponse(responseCode = "403", description = "페이지 접근 권한이 없음"),
+			@ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
 	public ResTemplate<StoreSearchResponse> searchStores(
 		@RequestParam(name = "keyword") String keyword,
 		@RequestParam(name = "category", defaultValue = "all") String category,

--- a/src/main/java/com/groom/swipo/domain/store/dto/StoreDetail.java
+++ b/src/main/java/com/groom/swipo/domain/store/dto/StoreDetail.java
@@ -1,0 +1,36 @@
+package com.groom.swipo.domain.store.dto;
+
+import java.util.List;
+
+import com.groom.swipo.domain.store.entity.Store;
+
+import lombok.Builder;
+
+@Builder
+public record StoreDetail(
+	Long storeId,
+	String name,
+	String address,
+	Integer percent,
+	Double stars,
+	boolean isWish,
+	Integer reviewsNum,
+	String review,
+	Integer imagesNum,
+	List<String> imageUrls
+) {
+	public static StoreDetail of(Store store, Double stars, boolean isWish, String review, List<String> images) {
+		return StoreDetail.builder()
+			.storeId(store.getId())
+			.name(store.getName())
+			.address(store.getAddress())
+			.percent(store.getPercent())
+			.stars(stars)
+			.isWish(isWish)
+			.reviewsNum(store.getReviews().size())
+			.review(review)
+			.imagesNum(images.size())
+			.imageUrls(images)
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/store/dto/response/StoreSearchResponse.java
+++ b/src/main/java/com/groom/swipo/domain/store/dto/response/StoreSearchResponse.java
@@ -1,0 +1,21 @@
+package com.groom.swipo.domain.store.dto.response;
+
+import java.util.List;
+
+import com.groom.swipo.domain.store.dto.StoreDetail;
+import com.groom.swipo.global.common.PageInfo;
+
+import lombok.Builder;
+
+@Builder
+public record StoreSearchResponse(
+	PageInfo pageInfo,
+	List<StoreDetail> stores
+) {
+	public static StoreSearchResponse of(PageInfo pageInfo, List<StoreDetail> stores) {
+		return StoreSearchResponse.builder()
+			.pageInfo(pageInfo)
+			.stores(stores)
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/store/entity/Store.java
+++ b/src/main/java/com/groom/swipo/domain/store/entity/Store.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.groom.swipo.domain.payment.entity.Paylist;
 import com.groom.swipo.domain.point.entity.Cardlist;
 import com.groom.swipo.domain.point.entity.MyPiece;
+import com.groom.swipo.domain.store.entity.enums.StoreCategory;
 import com.groom.swipo.domain.store.entity.enums.StoreType;
 import com.groom.swipo.global.common.enums.Area;
 import com.groom.swipo.global.entity.BaseEntity;
@@ -38,8 +39,12 @@ public class Store extends BaseEntity {
 	private String name;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
+	@Column(nullable = false)
 	private StoreType type;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private StoreCategory category;
 
 	private String address;
 
@@ -83,9 +88,11 @@ public class Store extends BaseEntity {
 
 	// 기타
 	@Builder
-	private Store(String name, StoreType type, String address, Double latitude, Double longitude, Integer percent) {
+	private Store(String name, StoreType type, StoreCategory category, String address, Double latitude,
+		Double longitude, Integer percent) {
 		this.name = name;
 		this.type = type;
+		this.category = category;
 		this.address = address;
 		this.latitude = latitude;
 		this.longitude = longitude;

--- a/src/main/java/com/groom/swipo/domain/store/entity/enums/StoreCategory.java
+++ b/src/main/java/com/groom/swipo/domain/store/entity/enums/StoreCategory.java
@@ -1,5 +1,5 @@
 package com.groom.swipo.domain.store.entity.enums;
 
 public enum StoreCategory {
-	ALL, CAFE, DESSERT, RESTAURANT, MART, PROP, LODGMENT
+	CAFE, DESSERT, RESTAURANT, MART, PROP, LODGMENT
 }

--- a/src/main/java/com/groom/swipo/domain/store/entity/enums/StoreCategory.java
+++ b/src/main/java/com/groom/swipo/domain/store/entity/enums/StoreCategory.java
@@ -1,0 +1,5 @@
+package com.groom.swipo.domain.store.entity.enums;
+
+public enum StoreCategory {
+	ALL, CAFE, DESSERT, RESTAURANT, MART, PROP, LODGMENT
+}

--- a/src/main/java/com/groom/swipo/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/groom/swipo/domain/store/repository/StoreRepository.java
@@ -28,4 +28,20 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 		@Param("longitude") double longitude,
 		@Param("radius") double radius
 	);
+
+	@Query("""
+		    SELECT s FROM Store s
+		    LEFT JOIN s.wishlists w ON w.isWish = true
+		    GROUP BY s
+		    ORDER BY COUNT(w) DESC
+		""")
+	List<Store> findPopularStores();
+
+	@Query("""
+		    SELECT s FROM Store s
+		    LEFT JOIN s.reviews r
+		    GROUP BY s
+		    ORDER BY COALESCE(AVG(r.star), 0) DESC
+		""")
+	List<Store> findTopRatedStores();
 }

--- a/src/main/java/com/groom/swipo/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/groom/swipo/domain/store/repository/StoreRepository.java
@@ -29,6 +29,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 		@Param("radius") double radius
 	);
 
+	// 관심 등록 수가 많은 순으로 가게 조회
 	@Query("""
 		    SELECT s FROM Store s
 		    LEFT JOIN s.wishlists w ON w.isWish = true
@@ -37,6 +38,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 		""")
 	List<Store> findPopularStores();
 
+	// 별점 평균이 높은 순으로 가게 조회
 	@Query("""
 		    SELECT s FROM Store s
 		    LEFT JOIN s.reviews r

--- a/src/main/java/com/groom/swipo/domain/store/service/StoreService.java
+++ b/src/main/java/com/groom/swipo/domain/store/service/StoreService.java
@@ -9,15 +9,18 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groom.swipo.domain.store.dto.StoreDetail;
 import com.groom.swipo.domain.store.dto.StoreInfo;
 import com.groom.swipo.domain.store.dto.StoreTabInfo;
 import com.groom.swipo.domain.store.dto.response.MapQueryResponse;
 import com.groom.swipo.domain.store.dto.response.MapStoreDetailResponse;
 import com.groom.swipo.domain.store.dto.response.MapTabViewResponse;
+import com.groom.swipo.domain.store.dto.response.StoreSearchResponse;
 import com.groom.swipo.domain.store.entity.Reviews;
 import com.groom.swipo.domain.store.entity.Store;
 import com.groom.swipo.domain.store.entity.StoreImage;
 import com.groom.swipo.domain.store.entity.Wishlist;
+import com.groom.swipo.domain.store.entity.enums.StoreCategory;
 import com.groom.swipo.domain.store.entity.enums.StoreType;
 import com.groom.swipo.domain.store.exception.StoreNotFoundException;
 import com.groom.swipo.domain.store.repository.ReviewsRepository;
@@ -27,6 +30,7 @@ import com.groom.swipo.domain.store.repository.WishilistRepository;
 import com.groom.swipo.domain.user.entity.User;
 import com.groom.swipo.domain.user.exception.UserNotFoundException;
 import com.groom.swipo.domain.user.repository.UserRepository;
+import com.groom.swipo.global.common.PageInfo;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,6 +38,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreService {
+
+	private static final int PAGE_SIZE = 5;
 
 	private final UserRepository userRepository;
 	private final WishilistRepository wishilistRepository;
@@ -141,5 +147,100 @@ public class StoreService {
 		return stores == null ? List.of() : stores.stream()
 			.limit(limit)
 			.collect(Collectors.toList());
+	}
+
+	public StoreSearchResponse searchStores(String keyword, String category, String type, int page,
+		Principal principal) {
+		Long userId = Long.parseLong(principal.getName());
+		User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+		List<Store> stores = storeRepository.findAll();
+		stores = filterByKeyword(stores, keyword);
+		stores = filterByCategory(stores, category);
+		stores = filterByType(stores, type, user);
+
+		PageInfo pageInfo = PageInfo.builder()
+			.currentPage(page)
+			.totalPages((int)Math.ceil((double)stores.size() / PAGE_SIZE))
+			.totalItems(stores.size())
+			.build();
+
+		List<StoreDetail> storeDetails = stores.stream()
+			.skip((long)page * PAGE_SIZE)
+			.limit(PAGE_SIZE)
+			.map(store -> convertToStoreDetail(store, user))
+			.toList();
+
+		return StoreSearchResponse.of(pageInfo, storeDetails);
+	}
+
+	private List<Store> filterByKeyword(List<Store> stores, String keyword) {
+		if (keyword == null || keyword.isBlank()) {
+			return stores;
+		}
+
+		return stores.stream()
+			.filter(store -> store.getName().contains(keyword) || store.getAddress().contains(keyword))
+			.toList();
+	}
+
+	private List<Store> filterByCategory(List<Store> stores, String category) {
+		if (category.equals("all")) {
+			return stores;
+		}
+
+		try {
+			return stores.stream()
+				.filter(store -> store.getCategory().equals(StoreCategory.valueOf(category.toUpperCase())))
+				.toList();
+		} catch (IllegalArgumentException e) {
+			throw new StoreNotFoundException("존재하지 않는 카테고리입니다.");
+		}
+	}
+
+	private List<Store> filterByType(List<Store> stores, String type, User user) {
+		return switch (type) {
+			case "pick" -> stores.stream()
+				.filter(store -> store.getType() == StoreType.PICK)
+				.toList();
+			case "trend" -> stores.stream()
+				.filter(store -> store.getType() == StoreType.TREND)
+				.toList();
+			case "taste" -> stores.stream()
+				.filter(store -> store.getType() == StoreType.TASTE)
+				.toList();
+			case "wish" -> stores.stream()
+				.filter(store -> wishilistRepository.existsByUserAndStoreAndIsWishTrue(user, store))
+				.toList();
+			case "popular" -> storeRepository.findPopularStores();
+			case "star" -> storeRepository.findTopRatedStores();
+			case "near" -> stores;
+			default -> throw new StoreNotFoundException("존재하지 않는 타입입니다.");
+		};
+	}
+
+	private StoreDetail convertToStoreDetail(Store store, User user) {
+		Double averageStars = store.getReviews().stream()
+			.mapToDouble(Reviews::getStar)
+			.average()
+			.stream()
+			.map(avg -> Math.round(avg * 10) / 10.0)
+			.findFirst()
+			.orElse(0.0);
+
+		String topReview = store.getReviews().stream()
+			.map(Reviews::getComment)
+			.findFirst()
+			.orElse(null);
+
+		List<String> images = store.getStoreImages().stream()
+			.map(StoreImage::getUrl)
+			.toList();
+
+		boolean isWish = wishilistRepository.findByUserAndStore(user, store)
+			.map(Wishlist::isWish)
+			.orElse(false);
+
+		return StoreDetail.of(store, averageStars, isWish, topReview, images);
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/store/service/StoreService.java
+++ b/src/main/java/com/groom/swipo/domain/store/service/StoreService.java
@@ -155,16 +155,20 @@ public class StoreService {
 		User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
 		List<Store> stores = storeRepository.findAll();
+
+		// 필터링: 키워드, 카테고리, 타입
 		stores = filterByKeyword(stores, keyword);
 		stores = filterByCategory(stores, category);
 		stores = filterByType(stores, type, user);
 
+		// 페이지 정보 생성
 		PageInfo pageInfo = PageInfo.builder()
 			.currentPage(page)
 			.totalPages((int)Math.ceil((double)stores.size() / PAGE_SIZE))
 			.totalItems(stores.size())
 			.build();
 
+		// 현재 페이지에 해당하는 데이터로 변환
 		List<StoreDetail> storeDetails = stores.stream()
 			.skip((long)page * PAGE_SIZE)
 			.limit(PAGE_SIZE)
@@ -174,6 +178,7 @@ public class StoreService {
 		return StoreSearchResponse.of(pageInfo, storeDetails);
 	}
 
+	// 키워드 필터링: 가게명이나 주소에 키워드 포함 여부
 	private List<Store> filterByKeyword(List<Store> stores, String keyword) {
 		if (keyword == null || keyword.isBlank()) {
 			return stores;
@@ -184,6 +189,7 @@ public class StoreService {
 			.toList();
 	}
 
+	// 카테고리 필터링: 카테고리가 존재하지 않으면 예외 발생
 	private List<Store> filterByCategory(List<Store> stores, String category) {
 		if (category.equals("all")) {
 			return stores;
@@ -198,6 +204,7 @@ public class StoreService {
 		}
 	}
 
+	// 타입 필터링: 거리순 로직 개발 필요
 	private List<Store> filterByType(List<Store> stores, String type, User user) {
 		return switch (type) {
 			case "pick" -> stores.stream()
@@ -219,6 +226,7 @@ public class StoreService {
 		};
 	}
 
+	// Store 데이터를 StoreDetail로 변환
 	private StoreDetail convertToStoreDetail(Store store, User user) {
 		Double averageStars = store.getReviews().stream()
 			.mapToDouble(Reviews::getStar)

--- a/src/main/java/com/groom/swipo/domain/user/entity/VerificationCode.java
+++ b/src/main/java/com/groom/swipo/domain/user/entity/VerificationCode.java
@@ -1,7 +1,6 @@
 package com.groom.swipo.domain.user.entity;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 import com.groom.swipo.global.entity.BaseEntity;
 

--- a/src/main/java/com/groom/swipo/domain/user/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/groom/swipo/domain/user/repository/VerificationCodeRepository.java
@@ -1,7 +1,5 @@
 package com.groom.swipo.domain.user.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/groom/swipo/global/common/PageInfo.java
+++ b/src/main/java/com/groom/swipo/global/common/PageInfo.java
@@ -1,0 +1,20 @@
+package com.groom.swipo.global.common;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Builder;
+
+@Builder
+public record PageInfo(
+	int currentPage,
+	int totalPages,
+	long totalItems
+) {
+	public static <T> PageInfo from(Page<T> entityPage) {
+		return PageInfo.builder()
+			.currentPage(entityPage.getNumber())
+			.totalPages(entityPage.getTotalPages())
+			.totalItems(entityPage.getTotalElements())
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/global/config/SecurityConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
 		"swagger-ui/**",
 		"v3/api-docs/**",
 		"/v1/**",
-		"/profile"
+		"/profile",
+		"/**"  // 테스트용
 	};
 
 	@Bean

--- a/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
@@ -6,8 +6,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
@@ -28,6 +31,8 @@ public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
+		String authHeader = "Authorization";
+
 		Server localServer = new Server();
 		localServer.description("Local Server")
 			.url(localUrl);
@@ -38,6 +43,13 @@ public class SwaggerConfig {
 
 		return new OpenAPI()
 			.info(apiInfo())
+			.addSecurityItem(new SecurityRequirement().addList(authHeader))
+			.components(new Components()
+				.addSecuritySchemes(authHeader, new SecurityScheme()
+					.name(authHeader)
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("Bearer")
+					.bearerFormat("accessToken")))
 			.servers(Arrays.asList(localServer, prodServer));
 	}
 }

--- a/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/SwaggerConfig.java
@@ -50,6 +50,6 @@ public class SwaggerConfig {
 					.type(SecurityScheme.Type.HTTP)
 					.scheme("Bearer")
 					.bearerFormat("accessToken")))
-			.servers(Arrays.asList(localServer, prodServer));
+			.servers(Arrays.asList(prodServer, localServer));
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #12, #16 

## 💬 리뷰 포인트
> Store API - `가게 검색`, Payment API - `결제내역 저장` 구현

## 🚀 상세 설명
> Store API - `가게 검색`, Payment API - `결제내역 저장` 구현했습니다.

> **가게 검색**
`keyword, category, type, page`로 필터링된 가게 리스트를 검색합니다. 고려해야될 점이 많다보니 각각에 대해 메서드로 분리하였고, 스트림을 적극 활용하여 필터링을 거치도록 구현했습니다. 필터링된 가게들을 기준으로 페이지 정보를 생성하고, 해당하는 페이지의 가게 리스트를 반환합니다.
현재 거리순 조회는 모든 데이터를 불러옵니다. 이후 사용자 좌표값을 받아서 추가 구현 예정이고, 쿼리문도 리팩토링해보고자 합니다.

> **결제내역 저장**
기존 평문에서 해시된 비밀번호와 비교하는 로직으로 수정하였고, 최근 이용내역이 보이기에 결제완료 처리되면 내역이 저장되도록 구현했습니다.

## 📸 스크린샷
>**가게 검색**
가게 더미 데이터를 생성하여 테스트를 진행했습니다.

<img width="1440" alt="가게 검색 - 1" src="https://github.com/user-attachments/assets/11101743-1551-43e2-bd11-62cae61e2487">

<img width="1440" alt="가게 검색 - 2" src="https://github.com/user-attachments/assets/f421dfdf-df36-4024-b251-cb8840dc3a0a">

<img width="1440" alt="가게검색 - 3" src="https://github.com/user-attachments/assets/d97430a8-c79a-44b8-9af8-b778ec8a7e6b">

> **결제내역 저장**
<img width="1440" alt="결제완료" src="https://github.com/user-attachments/assets/ef17aaed-64c0-4cd1-8d35-c0693bded2cc">

<img width="1136" alt="결제내역" src="https://github.com/user-attachments/assets/977c9254-059e-4c6d-8107-6e82007dfba8">

## 📢 노트