### PR TITLE
[FEAT] 스윕페이/포인트 홈 조회 및 카드등록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 
 	// 휴대폰 인증 API (nurigo)
 	implementation 'net.nurigo:sdk:4.3.0'
+
+	// S3
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }
 
 // iamport

--- a/src/main/java/com/groom/swipo/domain/auth/service/S3Service.java
+++ b/src/main/java/com/groom/swipo/domain/auth/service/S3Service.java
@@ -1,0 +1,48 @@
+package com.groom.swipo.domain.auth.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+public class S3Service {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.s3.bucket}")
+	private String bucketName;
+
+	public S3Service(AmazonS3 amazonS3) {
+		this.amazonS3 = amazonS3;
+	}
+
+	public String uploadImage(MultipartFile image) {
+		String fileName = UUID.randomUUID().toString() + "-" + image.getOriginalFilename();
+		try (InputStream inputStream = image.getInputStream()) {
+			ObjectMetadata metadata = new ObjectMetadata(); // 콘텐츠 길이 지정
+			metadata.setContentLength(image.getSize());
+
+			amazonS3.putObject(new PutObjectRequest(bucketName, fileName, inputStream, metadata));
+			return amazonS3.getUrl(bucketName, fileName).toString();
+		} catch (IOException e) {
+			throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);
+		}
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/payment/dto/PaylistInfo.java
+++ b/src/main/java/com/groom/swipo/domain/payment/dto/PaylistInfo.java
@@ -1,0 +1,25 @@
+package com.groom.swipo.domain.payment.dto;
+
+import java.time.LocalDateTime;
+
+import com.groom.swipo.domain.payment.entity.Paylist;
+import com.groom.swipo.domain.store.entity.Store;
+
+import lombok.Builder;
+
+@Builder
+public record PaylistInfo(
+	String paylistId,
+	Integer amount,
+	String storeName,
+	LocalDateTime createAt
+) {
+	public static PaylistInfo of(Paylist paylist, Store store){
+		return PaylistInfo.builder()
+			.paylistId(String.valueOf(paylist.getId()))
+			.amount((int)paylist.getValue())
+			.amount(Integer.valueOf(store.getName()))
+			.createAt(paylist.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/payment/dto/PaylistInfo.java
+++ b/src/main/java/com/groom/swipo/domain/payment/dto/PaylistInfo.java
@@ -18,7 +18,7 @@ public record PaylistInfo(
 		return PaylistInfo.builder()
 			.paylistId(String.valueOf(paylist.getId()))
 			.amount((int)paylist.getValue())
-			.amount(Integer.valueOf(store.getName()))
+			.storeName(store.getName())
 			.createAt(paylist.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/groom/swipo/domain/payment/exception/PayNotFoundException.java
+++ b/src/main/java/com/groom/swipo/domain/payment/exception/PayNotFoundException.java
@@ -1,0 +1,13 @@
+package com.groom.swipo.domain.payment.exception;
+
+import com.groom.swipo.global.error.exception.NotFoundGroupException;
+
+public class PayNotFoundException extends NotFoundGroupException {
+	public PayNotFoundException(String message) {
+		super(message);
+	}
+
+	public PayNotFoundException() {
+		super("Pay not found for user.");
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/payment/exception/PayNotFoundException.java
+++ b/src/main/java/com/groom/swipo/domain/payment/exception/PayNotFoundException.java
@@ -8,6 +8,6 @@ public class PayNotFoundException extends NotFoundGroupException {
 	}
 
 	public PayNotFoundException() {
-		super("Pay not found for user.");
+		super("해당 페이를 찾지 못했습니다.");
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/payment/repository/PayRepository.java
+++ b/src/main/java/com/groom/swipo/domain/payment/repository/PayRepository.java
@@ -1,10 +1,14 @@
 package com.groom.swipo.domain.payment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.groom.swipo.domain.payment.entity.Pay;
+import com.groom.swipo.domain.user.entity.User;
 
 @Repository
 public interface PayRepository extends JpaRepository<Pay, Long> {
+	Optional<Pay> findByUser(User user);
 }

--- a/src/main/java/com/groom/swipo/domain/payment/repository/PaylistRepository.java
+++ b/src/main/java/com/groom/swipo/domain/payment/repository/PaylistRepository.java
@@ -1,10 +1,14 @@
 package com.groom.swipo.domain.payment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.groom.swipo.domain.payment.entity.Pay;
 import com.groom.swipo.domain.payment.entity.Paylist;
 
 @Repository
 public interface PaylistRepository extends JpaRepository<Paylist, Long> {
+	List<Paylist> findTop5ByPayOrderByCreatedAtDesc(Pay pay);
 }

--- a/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
+++ b/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.groom.swipo.domain.point.dto.Request.SwipstoneSwapRequest;
 import com.groom.swipo.domain.point.dto.Response.PointHomeResponse;
@@ -43,6 +45,29 @@ public class PointController {
 	public ResTemplate<PointHomeResponse> getHome(Principal principal) {
 		PointHomeResponse data = pointService.getHome(principal);
 		return new ResTemplate<>(HttpStatus.OK, "조회 성공", data);
+	}
+
+	@PostMapping("/card-register")
+	@Operation(
+		summary = "포인트 카드 등록",
+		description = "지역 정보와 이미지 파일을 사용하여 포인트 카드를 등록합니다.",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "201", description = "카드 등록 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+			@ApiResponse(responseCode = "403", description = "동네 인증이 안된 경우"),
+			@ApiResponse(responseCode = "409", description = "중복 카드 등록"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
+	public ResTemplate<Void> registerCard(
+		@RequestPart("region") String region,
+		@RequestPart(value = "custom_image", required = false) MultipartFile customImage,
+		Principal principal) {
+
+		pointService.registerCard(region, customImage, principal);
+		return new ResTemplate<>(HttpStatus.CREATED, "카드 등록 성공");
 	}
 
 

--- a/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
+++ b/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
@@ -54,9 +54,8 @@ public class PointController {
 		security = {},
 		responses = {
 			@ApiResponse(responseCode = "201", description = "카드 등록 성공"),
-			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "400", description = "유효하지 않은 동네"),
 			@ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
-			@ApiResponse(responseCode = "403", description = "동네 인증이 안된 경우"),
 			@ApiResponse(responseCode = "409", description = "중복 카드 등록"),
 			@ApiResponse(responseCode = "500", description = "서버 오류")
 		}

--- a/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
+++ b/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.groom.swipo.domain.point.dto.Request.SwipstoneSwapRequest;
+import com.groom.swipo.domain.point.dto.Response.PointHomeResponse;
 import com.groom.swipo.domain.point.dto.Response.SwipstoneResponse;
 import com.groom.swipo.domain.point.dto.Response.SwipstoneSwapResponse;
 import com.groom.swipo.domain.point.service.PointService;
@@ -26,6 +27,24 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "포인트", description = "포인트 관련 API 그룹")
 public class PointController {
 	private final PointService pointService;
+
+	@GetMapping("/home")
+	@Operation(
+		summary = "스윕페이/포인트 홈 조회",
+		description = "상단 스웹페이 탭 클릭시 조회되는 정보 제공",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
+	public ResTemplate<PointHomeResponse> getHome(Principal principal) {
+		PointHomeResponse data = pointService.getHome(principal);
+		return new ResTemplate<>(HttpStatus.OK, "조회 성공", data);
+	}
+
 
 	@GetMapping("/swipstone")
 	@Operation(

--- a/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
@@ -1,0 +1,22 @@
+package com.groom.swipo.domain.point.dto;
+
+import com.groom.swipo.domain.point.entity.Card;
+
+import lombok.Builder;
+
+@Builder
+public record CardInfo(
+	String cardId,
+	String region,
+	Integer point,
+	String customImage
+) {
+	public static CardInfo of(Card card) {
+		return CardInfo.builder()
+			.cardId(String.valueOf(card.getId()))
+			.region(card.getArea().getRegionName())
+			.point(card.getTotalPoint())
+			.customImage(card.getCustomeImage())
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
@@ -11,7 +11,7 @@ public record CardInfo(
 	Integer point,
 	String customImage
 ) {
-	public static CardInfo of(Card card) {
+	public static CardInfo from(Card card) {
 		return CardInfo.builder()
 			.cardId(String.valueOf(card.getId()))
 			.region(card.getArea().getRegionName())

--- a/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/CardInfo.java
@@ -16,7 +16,7 @@ public record CardInfo(
 			.cardId(String.valueOf(card.getId()))
 			.region(card.getArea().getRegionName())
 			.point(card.getTotalPoint())
-			.customImage(card.getCustomeImage())
+			.customImage(card.getCustomImage())
 			.build();
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/point/dto/Response/PointHomeResponse.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/Response/PointHomeResponse.java
@@ -1,0 +1,26 @@
+package com.groom.swipo.domain.point.dto.Response;
+
+import java.util.List;
+
+import com.groom.swipo.domain.payment.dto.PaylistInfo;
+import com.groom.swipo.domain.payment.entity.Pay;
+import com.groom.swipo.domain.point.dto.CardInfo;
+
+import lombok.Builder;
+
+@Builder
+public record PointHomeResponse(
+	Integer balance, // 페이잔액
+	Integer totalCards, //사용자가 보유한 모든 지역 카드 수
+	List<CardInfo> cards,
+	List<PaylistInfo> paylistInfos
+) {
+	public static PointHomeResponse of(Pay pay, Integer totalCards, List<CardInfo> cards, List<PaylistInfo> paylistInfos){
+		return PointHomeResponse.builder()
+			.balance(pay.getTotalPay())
+			.totalCards(totalCards)
+			.cards(cards)
+			.paylistInfos(paylistInfos)
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/point/entity/Card.java
+++ b/src/main/java/com/groom/swipo/domain/point/entity/Card.java
@@ -35,17 +35,14 @@ public class Card extends BaseEntity {
 	@Column(name = "card_id")
 	private Long id;
 
-	@Column(nullable = false)
-	private String number;
-
 	private String contents;
 
 	@Column(nullable = false)
 	@ColumnDefault("0")
-	private Integer totalPoint;
+	private Integer totalPoint = 0;
 
 	@Column(nullable = false)
-	private String customeImage;
+	private String customImage;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -61,11 +58,11 @@ public class Card extends BaseEntity {
 	private List<Cardlist> cardlists = new ArrayList<>();
 
 	@Builder
-	private Card(String number, String contents, Integer totalPoint, String customeImage, Area area) {
-		this.number = number;
-		this.contents = contents;
-		this.totalPoint = totalPoint;
-		this.customeImage = customeImage;
+	private Card(User user, String customImage, Area area) {
+		this.user = user;
+		this.contents = "";
+		this.totalPoint = 0; // 생성자에서 명시적으로 기본값 설정
+		this.customImage = customImage;
 		this.area = area;
 	}
 

--- a/src/main/java/com/groom/swipo/domain/point/entity/Card.java
+++ b/src/main/java/com/groom/swipo/domain/point/entity/Card.java
@@ -39,7 +39,7 @@ public class Card extends BaseEntity {
 
 	@Column(nullable = false)
 	@ColumnDefault("0")
-	private Integer totalPoint = 0;
+	private Integer totalPoint;
 
 	@Column(nullable = false)
 	private String customImage;
@@ -61,7 +61,7 @@ public class Card extends BaseEntity {
 	private Card(User user, String customImage, Area area) {
 		this.user = user;
 		this.contents = "";
-		this.totalPoint = 0; // 생성자에서 명시적으로 기본값 설정
+		this.totalPoint = 0; //default 0
 		this.customImage = customImage;
 		this.area = area;
 	}

--- a/src/main/java/com/groom/swipo/domain/point/exception/DuplicateCardException.java
+++ b/src/main/java/com/groom/swipo/domain/point/exception/DuplicateCardException.java
@@ -1,0 +1,12 @@
+package com.groom.swipo.domain.point.exception;
+
+import com.groom.swipo.global.error.exception.ConflictGroupException;
+
+public class DuplicateCardException extends ConflictGroupException {
+	public DuplicateCardException(String message) {
+		super(message);
+	}
+	public DuplicateCardException(){
+		this("이미 해당 지역카드가 존재합니다.");
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/point/exception/InvalidRegionException.java
+++ b/src/main/java/com/groom/swipo/domain/point/exception/InvalidRegionException.java
@@ -1,0 +1,13 @@
+package com.groom.swipo.domain.point.exception;
+
+import com.groom.swipo.global.error.exception.InvalidGroupException;
+
+public class InvalidRegionException extends InvalidGroupException {
+
+	public InvalidRegionException(String message) {
+		super(message);
+	}
+	public InvalidRegionException(){
+		this("지역명을 잘못 작성하였거나 유효하지 않는 지역입니다.");
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/point/repository/CardRepository.java
+++ b/src/main/java/com/groom/swipo/domain/point/repository/CardRepository.java
@@ -1,10 +1,14 @@
 package com.groom.swipo.domain.point.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.groom.swipo.domain.point.entity.Card;
+import com.groom.swipo.domain.user.entity.User;
 
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
+	List<Card> findAllByUser(User user);
 }

--- a/src/main/java/com/groom/swipo/domain/point/repository/CardRepository.java
+++ b/src/main/java/com/groom/swipo/domain/point/repository/CardRepository.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Repository;
 
 import com.groom.swipo.domain.point.entity.Card;
 import com.groom.swipo.domain.user.entity.User;
+import com.groom.swipo.global.common.enums.Area;
 
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
 	List<Card> findAllByUser(User user);
+	boolean existsByUserAndArea(User user, Area area);
 }

--- a/src/main/java/com/groom/swipo/domain/point/service/PointService.java
+++ b/src/main/java/com/groom/swipo/domain/point/service/PointService.java
@@ -54,7 +54,7 @@ public class PointService {
 		// 사용자 카드 정보 조회
 		List<Card> cards = cardRepository.findAllByUser(user);
 		List<CardInfo> cardInfos = cards.stream()
-			.map(CardInfo::of)
+			.map(CardInfo::from)
 			.toList();
 
 		// 최근 페이 거래 내역 조회 (최대 5개)

--- a/src/main/java/com/groom/swipo/global/common/enums/Area.java
+++ b/src/main/java/com/groom/swipo/global/common/enums/Area.java
@@ -1,32 +1,37 @@
 package com.groom.swipo.global.common.enums;
 
 public enum Area {
-	CODE_02("02"), // 서울
-	CODE_05("05"), // 경남
-	CODE_031("031"), // 경기도
-	CODE_032("032"), // 인천
-	CODE_033("033"), // 강원
-	CODE_041("041"), // 충남
-	CODE_042("042"), // 대전
-	CODE_043("043"), // 충북
-	CODE_044("044"), // 세종
-	CODE_051("051"), // 부산
-	CODE_052("052"), // 울산
-	CODE_053("053"), // 대구
-	CODE_054("054"), // 경북
-	CODE_061("061"), // 전남
-	CODE_062("062"), // 광주
-	CODE_063("063"), // 전북
-	CODE_064("064"); // 제주
-
+	CODE_02("02", "서울"),
+	CODE_031("031", "경기도"),
+	CODE_032("032", "인천"),
+	CODE_033("033", "강원"),
+	CODE_041("041", "충남"),
+	CODE_042("042", "대전"),
+	CODE_043("043", "충북"),
+	CODE_044("044", "세종"),
+	CODE_051("051", "부산"),
+	CODE_052("052", "울산"),
+	CODE_053("053", "대구"),
+	CODE_054("054", "경북"),
+	CODE_055("055", "경남"),
+	CODE_061("061", "전남"),
+	CODE_062("062", "광주"),
+	CODE_063("063", "전북"),
+	CODE_064("064", "제주");
 
 	private final String code;
+	private final String regionName; // 지역명 추가
 
-	Area(String code) {
+	Area(String code, String regionName) {
 		this.code = code;
+		this.regionName = regionName;
 	}
 
 	public String getCode() {
 		return code;
+	}
+
+	public String getRegionName() { // 지역명을 반환하는 메서드
+		return regionName;
 	}
 }

--- a/src/main/java/com/groom/swipo/global/common/enums/Area.java
+++ b/src/main/java/com/groom/swipo/global/common/enums/Area.java
@@ -1,5 +1,8 @@
 package com.groom.swipo.global.common.enums;
 
+import java.util.Arrays;
+import com.groom.swipo.domain.point.exception.InvalidRegionException;
+
 public enum Area {
 	CODE_02("02", "서울"),
 	CODE_031("031", "경기도"),
@@ -20,7 +23,7 @@ public enum Area {
 	CODE_064("064", "제주");
 
 	private final String code;
-	private final String regionName; // 지역명 추가
+	private final String regionName;
 
 	Area(String code, String regionName) {
 		this.code = code;
@@ -31,7 +34,15 @@ public enum Area {
 		return code;
 	}
 
-	public String getRegionName() { // 지역명을 반환하는 메서드
+	public String getRegionName() {
 		return regionName;
+	}
+
+	// 지역명을 기준으로 Area 반환
+	public static Area fromRegionName(String regionName) {
+		return Arrays.stream(values())
+			.filter(area -> area.getRegionName().equals(regionName))
+			.findFirst()
+			.orElseThrow(InvalidRegionException::new); // 여기서 에러 핸들링하는게 맞겠죠..? 클린하겠죠? ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ
 	}
 }

--- a/src/main/java/com/groom/swipo/global/config/S3ClientConfig.java
+++ b/src/main/java/com/groom/swipo/global/config/S3ClientConfig.java
@@ -1,0 +1,32 @@
+package com.groom.swipo.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3ClientConfig {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,15 @@ sms:
 app:
   local-url: ${app.local-url}
   prod-url: ${app.prod-url}
+
+cloud:
+  aws:
+    credentials:
+      accessKey: ${cloud.aws.credentials.accessKey}
+      secretKey: ${cloud.aws.credentials.secretKey}
+    region:
+      static: ${cloud.aws.region.static}
+    stack:
+      auto: false
+  s3:
+    bucket: ${cloud.s3.bucket}


### PR DESCRIPTION
## 📌 이슈 번호
> #25 
## 💬 리뷰 포인트
> Point API - `스윕페이/포인트 홈 조회`, `포인트카드 등록` 구현했습니다.
## 🚀 상세 설명
> **스윕페이/포인트 홈 조회**
앱에서 스윕페이 탭을 누를 경우 조회되는 정보를 표시합니다. 이때 해당 API는 `사용자 Pay 정보`, `사용자 카드 정보`, `최근 페이 거래내역 5개` 를 응답해줍니다.

> **포인트카드 등록**
지역 정보와 커스텀 카드 이미지 파일을 사용하여 포인트 카드를 만들 수 있습니다.
이때 정보는 `MultipartFile`로 Request를 받게 되고, 올바른 지역인지, 중복 카드는 있는지 여부를 확인한 후 이미지 파일을 `S3`에 저장하고 해당 url을 DB에 저장합니다

## 📸 스크린샷
> **스윕페이/포인트 홈 조회** 데이터 O/데이터 X
![image](https://github.com/user-attachments/assets/0fb5df26-7dac-456f-a286-8febcff02933)
![image](https://github.com/user-attachments/assets/a6f678e3-f0b9-4305-b998-9bfb7343d82d)

> **포인트카드 등록** 성공/실패
![image](https://github.com/user-attachments/assets/95d38a93-9d56-4b2b-a271-acfbeca61fb0)
![image](https://github.com/user-attachments/assets/fcac5009-d88e-41e3-ad53-e45fcf05a548)
![image](https://github.com/user-attachments/assets/0a3aec17-229a-41c0-b43d-4f77b7857ac1)


## 📢 노트
이제 끝이 살짝 보이는거 같기도...!?