### PR TITLE
[FEAT] 포인트 이전/이전 조회 API 

### DIFF
--- a/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
+++ b/src/main/java/com/groom/swipo/domain/point/controller/PointController.java
@@ -11,8 +11,11 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.groom.swipo.domain.point.dto.Request.PointTransferRequest;
 import com.groom.swipo.domain.point.dto.Request.SwipstoneSwapRequest;
 import com.groom.swipo.domain.point.dto.Response.PointHomeResponse;
+import com.groom.swipo.domain.point.dto.Response.PointTransferResponse;
+import com.groom.swipo.domain.point.dto.Response.PointTransferInfoResponse;
 import com.groom.swipo.domain.point.dto.Response.SwipstoneResponse;
 import com.groom.swipo.domain.point.dto.Response.SwipstoneSwapResponse;
 import com.groom.swipo.domain.point.service.PointService;
@@ -69,7 +72,6 @@ public class PointController {
 		return new ResTemplate<>(HttpStatus.CREATED, "카드 등록 성공");
 	}
 
-
 	@GetMapping("/swipstone")
 	@Operation(
 		summary = "스윕스톤 조회",
@@ -101,8 +103,43 @@ public class PointController {
 			@ApiResponse(responseCode = "500", description = "서버 오류")
 		}
 	)
-	public ResTemplate<SwipstoneSwapResponse> swapSwipstone(@RequestBody SwipstoneSwapRequest resquest, Principal principal) {
+	public ResTemplate<SwipstoneSwapResponse> swapSwipstone(@RequestBody SwipstoneSwapRequest resquest,
+		Principal principal) {
 		SwipstoneSwapResponse data = pointService.swapSwipstone(resquest, principal);
 		return new ResTemplate<>(HttpStatus.OK, "교환 성공", data);
+	}
+
+	@GetMapping("/transfer-info")
+	@Operation(
+		summary = "포인트 이전 조희",
+		description = "포인트 이전 페이지에 들어왔을떄 자신이 보유한 포인트 카드들 조회 가능",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "교환 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
+	public ResTemplate<PointTransferInfoResponse> getPointTransferInfo(Principal principal) {
+		PointTransferInfoResponse data= pointService.getPointTransferInfo(principal);
+		return new ResTemplate<>(HttpStatus.OK, "내 카드 조회 성공", data);
+	}
+
+	@PostMapping("/transefer")
+	@Operation(
+		summary = "포인트 이전",
+		description = "포인트 이전 페이지에서 포인트 이전을 클릭 시 ",
+		security = {},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "이전 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+			@ApiResponse(responseCode = "500", description = "서버 오류")
+		}
+	)
+	public ResTemplate<PointTransferResponse> pointTransfer(@RequestBody PointTransferRequest request, Principal principal) {
+		PointTransferResponse data = pointService.pointTransfer(request, principal);
+		return new ResTemplate<>(HttpStatus.OK, "이전 성공", data);
 	}
 }

--- a/src/main/java/com/groom/swipo/domain/point/dto/Request/PointTransferRequest.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/Request/PointTransferRequest.java
@@ -1,0 +1,8 @@
+package com.groom.swipo.domain.point.dto.Request;
+
+public record PointTransferRequest(
+	String fromCardId,
+	String toCardId,
+	Integer point
+){
+}

--- a/src/main/java/com/groom/swipo/domain/point/dto/Response/PointTransferInfoResponse.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/Response/PointTransferInfoResponse.java
@@ -1,0 +1,20 @@
+package com.groom.swipo.domain.point.dto.Response;
+
+import java.util.List;
+
+import com.groom.swipo.domain.point.dto.CardInfo;
+
+import lombok.Builder;
+
+@Builder
+public record PointTransferInfoResponse(
+	Integer cardNum,
+	List<CardInfo> cards
+) {
+	public static PointTransferInfoResponse of(Integer cardNum, List<CardInfo> cards){
+		return PointTransferInfoResponse.builder()
+			.cardNum(cardNum)
+			.cards(cards)
+			.build();
+	}
+}

--- a/src/main/java/com/groom/swipo/domain/point/dto/Response/PointTransferResponse.java
+++ b/src/main/java/com/groom/swipo/domain/point/dto/Response/PointTransferResponse.java
@@ -1,0 +1,22 @@
+package com.groom.swipo.domain.point.dto.Response;
+
+import com.groom.swipo.domain.point.entity.Card;
+
+import lombok.Builder;
+
+@Builder
+public record PointTransferResponse(
+	String fromCardId,
+	String toCardId,
+	Integer fromPoint,
+	Integer toPoint
+) {
+	public static PointTransferResponse of(Card fromCard, Card toCard) {
+		return PointTransferResponse.builder()
+			.fromCardId(String.valueOf(fromCard.getId()))
+			.toCardId(String.valueOf(toCard.getId()))
+			.fromPoint(fromCard.getTotalPoint())
+			.toPoint(toCard.getTotalPoint())
+			.build();
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #24 
## 💬 리뷰 포인트
> Point 파트 포인트 이전, 포인트 이전 조회 구현
## 🚀 상세 설명
> Point 파트 - `포인트 이전 조회`, `포인트 이전 API` 구현

> **포인트 이전 조회**
포인트 이전 뷰를 들어가게 됬을때 보이게 되는 포인트 카드들의 정보를 넘겨줍니다. `AccessToken` 안 `userId`를 기반으로 보유하고 있는 포인트 카드를 조회합니다.

> **포인트 이전 API**
포인트 이전 버튼을 클릭하게 되었을때 `보낼 카드 Id`값과 `받을 카드 Id`값을 이용해서 해당 카드들의 포인트를 더하거나 뺌으로 포인트 이전을 진행합니다. 

## 📸 스크린샷
> **포인트 이전 조회** 성공
<img width="924" alt="image" src="https://github.com/user-attachments/assets/b4266f0c-2753-4c03-bff4-3df45c4513e5">

> **포인트 이전 API** 성공/실패
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/e5ccb47b-ece4-46b3-966a-ac312efb957c">
<img width="971" alt="image" src="https://github.com/user-attachments/assets/bd7c01a5-3f28-40ab-9ed1-6590d4cf4737">
<img width="934" alt="image" src="https://github.com/user-attachments/assets/aa5ed2ca-b032-4fe1-8a60-32e71c57b4a4">


## 📢 노트